### PR TITLE
Make breadcrumbs more robust

### DIFF
--- a/layouts/default.slim
+++ b/layouts/default.slim
@@ -11,7 +11,7 @@ html.govuk-template lang='en'
       == render '/partials/breadcrumbs.*'
 
       main#main-content.govuk-main-wrapper
-        h1 = item[:title]
+        h1 = item[:title] || 'Insert title here'
 
         == yield
 

--- a/layouts/partials/breadcrumbs.slim
+++ b/layouts/partials/breadcrumbs.slim
@@ -4,6 +4,12 @@
     .govuk-breadcrumbs__list
       - breadcrumbs_trail.each do |ancestor|
         li.govuk-breadcrumbs__list-item
-          == link_to_unless_current(ancestor[:title],         \
-              ancestor.path, class: 'govuk-breadcrumbs__link' \
-            ).html_safe
+          - if ancestor
+            - if ancestor[:name]
+              == link_to_unless_current(ancestor[:title],         \
+                  ancestor.path, class: 'govuk-breadcrumbs__link' \
+                ).html_safe
+            - else
+              | Title missing
+          - else
+            | Page missing


### PR DESCRIPTION
If page titles were missing the generator would crash. Now it displays some helpful placeholder text instead.