### PR TITLE
Add Staticfile and some guidance on publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ been allocated a space, this prototype is ready to publish. We just need to
 give the app a name (see `manifest.yml`), log in (`cf login`) and push (`cf
 push`).
 
+If you want your prototype to be protected by [Basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
+you need to add a `Staticfile.auth`. CloudFoundry's documentation covers the process in
+[plenty of detail](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#basic-authentication).
+
 ## Adding content
 
 To add a new page create a `.gs` file in the `content` directory,

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Navigate to `http://localhost:3000` and if you see this, it worked!
 
 ![home page](docs/sample.png)
 
+## Publishing content
+
+Providing you have a  [GOV.UK PaaS](https://www.cloud.service.gov.uk/) and have
+been allocated a space, this prototype is ready to publish. We just need to
+give the app a name (see `manifest.yml`), log in (`cf login`) and push (`cf
+push`).
+
 ## Adding content
 
 To add a new page create a `.gs` file in the `content` directory,

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: output


### PR DESCRIPTION
Without the Staticfile, publishing to the PaaS wasn't working properly. The
Staticfile is required to inform CloudFoundry which directory to serve

https://docs.cloudfoundry.org/buildpacks/staticfile/index.html

Fixes #6
